### PR TITLE
Bug Fix: Model Weights Path Issue

### DIFF
--- a/predict_HIDE_results.py
+++ b/predict_HIDE_results.py
@@ -29,7 +29,8 @@ if __name__ == '__main__':
     if not os.path.isdir(out_path):
         os.mkdir(out_path)
     model = get_generator(config['model'])
-    model.load_state_dict(torch.load(args.weights_path))
+    weights_path = os.path.join('results', args.job_name, 'models', args.weight_name)
+    model.load_state_dict(torch.load(weights_path))
     model = model.cuda()
     test_time = 0
     iteration = 0

--- a/predict_RealBlur_J_test_results.py
+++ b/predict_RealBlur_J_test_results.py
@@ -30,7 +30,8 @@ if __name__ == '__main__':
     if not os.path.isdir(out_path):
         os.mkdir(out_path)
     model = get_generator(config['model'])
-    model.load_state_dict(torch.load(args.weights_path))
+    weights_path = os.path.join('results', args.job_name, 'models', args.weight_name)
+    model.load_state_dict(torch.load(weights_path))
     model = model.cuda()
     test_time = 0
     iteration = 0

--- a/predict_RealBlur_R_test_results.py
+++ b/predict_RealBlur_R_test_results.py
@@ -28,7 +28,8 @@ if __name__ == '__main__':
     blur_path = args.blur_path
     out_path = os.path.join('results', args.job_name, 'images_realr')
     model = get_generator(config['model'])
-    model.load_state_dict(torch.load(args.weights_path))
+    weights_path = os.path.join('results', args.job_name, 'models', args.weight_name)
+    model.load_state_dict(torch.load(weights_path))
     model = model.cuda()
     if not os.path.isdir(out_path):
         os.mkdir(out_path)


### PR DESCRIPTION
A bug was identified in the model weight loading process within the prediction scripts. The issue stemmed from the `weights_path` variable not being properly defined, causing the model loading to fail.

### Affected Files:
- `predict_RealBlur_R_test_results.py`
- `predict_RealBlur_J_test_results.py`
- `predict_HIDE_results.py`

### Resolution:
The bug was fixed by correctly defining the `weights_path` variable using the `os.path.join` method. This ensures the model weights are loaded from the specified directory.

### Updated Code:
```python
# Define the correct weights path
weights_path = os.path.join('results', args.job_name, 'models', args.weight_name)

# Load the model weights
model.load_state_dict(torch.load(weights_path))
```
### Issue:
Fixes #8 
